### PR TITLE
Implement example client mbedtls function stubs

### DIFF
--- a/crypto/includes/ngtcp2/ngtcp2_crypto_mbedtls.h
+++ b/crypto/includes/ngtcp2/ngtcp2_crypto_mbedtls.h
@@ -27,39 +27,11 @@
 
 #include <ngtcp2/ngtcp2.h>
 
-#include <openssl/ssl.h>
+#include <mbedtls/ssl.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @macrosection
- *
- * mbedtls specific error codes
- */
-
-/**
- * @macro
- *
- * :macro:`NGTCP2_CRYPTO_MBEDTLS_ERR_TLS_WANT_X509_LOOKUP` is the
- * error code which indicates that TLS handshake routine is
- * interrupted by X509 certificate lookup.  See
- * :macro:`SSL_ERROR_WANT_X509_LOOKUP` error description from
- * `SSL_do_handshake`.
- */
-#define NGTCP2_CRYPTO_OPENSSL_ERR_TLS_WANT_X509_LOOKUP -10001
-
-/**
- * @macro
- *
- * :macro:`NGTCP2_CRYPTO_MBEDTLS_ERR_TLS_WANT_CLIENT_HELLO_CB` is the
- * error code which indicates that TLS handshake routine is
- * interrupted by client hello callback.  See
- * :macro:`SSL_ERROR_WANT_CLIENT_HELLO_CB` error description from
- * `SSL_do_handshake`.
- */
-#define NGTCP2_CRYPTO_OPENSSL_ERR_TLS_WANT_CLIENT_HELLO_CB -10002
 
 /**
  * @function
@@ -70,16 +42,16 @@ extern "C" {
  */
 NGTCP2_EXTERN ngtcp2_crypto_level
 ngtcp2_crypto_mbedtls_from_ossl_encryption_level(
-    OSSL_ENCRYPTION_LEVEL ossl_level);
+    mbedtls_ssl_crypto_level mbed_crypto_level);
 
 /**
  * @function
  *
  * `ngtcp2_crypto_mbedtls_from_ngtcp2_crypto_level` translates
- * |crypto_level| to OSSL_ENCRYPTION_LEVEL.  This function is only
+ * |crypto_level| to mbedtls_ssl_crypto_level.  This function is only
  * available for mbedtls backend.
  */
-NGTCP2_EXTERN OSSL_ENCRYPTION_LEVEL
+NGTCP2_EXTERN mbedtls_ssl_crypto_level
 ngtcp2_crypto_mbedtls_from_ngtcp2_crypto_level(
     ngtcp2_crypto_level crypto_level);
 

--- a/crypto/mbedtls/mbedtls.c
+++ b/crypto/mbedtls/mbedtls.c
@@ -27,34 +27,38 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <assert.h>
+#include <string.h>
 
 #include <ngtcp2/ngtcp2_crypto.h>
 #include <ngtcp2/ngtcp2_crypto_mbedtls.h>
 
-#include <openssl/ssl.h>
-#include <openssl/evp.h>
-#include <openssl/kdf.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/aes.h>
+#include <mbedtls/cipher.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/gcm.h>
+#include <mbedtls/hkdf.h>
+#include <mbedtls/md.h>
 
 #include "shared.h"
 
-static size_t crypto_aead_max_overhead(const EVP_CIPHER *aead) {
-  switch (EVP_CIPHER_nid(aead)) {
-  case NID_aes_128_gcm:
-  case NID_aes_256_gcm:
-    return EVP_GCM_TLS_TAG_LEN;
-  case NID_chacha20_poly1305:
-    return EVP_CHACHAPOLY_TLS_TAG_LEN;
-  case NID_aes_128_ccm:
-    return EVP_CCM_TLS_TAG_LEN;
-  default:
-    assert(0);
-  }
+// All lengths are in bytes.
+#define AES_128_ECB_BLKLEN 16
+#define AES_128_GCM_KEYLEN 16
+#define AES_128_GCM_KEYLEN_BITS (AES_128_GCM_KEYLEN << 3)
+#define AES_128_GCM_TAGLEN 16
+#define AES_128_GCM_NONCELEN 12
+#define HP_MASK_LEN 5
+
+static size_t crypto_aead_max_overhead(void *aead) {
+  return AES_128_GCM_TAGLEN;
 }
 
 ngtcp2_crypto_ctx *ngtcp2_crypto_ctx_initial(ngtcp2_crypto_ctx *ctx) {
-  ngtcp2_crypto_aead_init(&ctx->aead, (void *)EVP_aes_128_gcm());
-  ctx->md.native_handle = (void *)EVP_sha256();
-  ctx->hp.native_handle = (void *)EVP_aes_128_ctr();
+  ngtcp2_crypto_aead_init(&ctx->aead, NULL);
+  ctx->md.native_handle = (void *)NULL;
+  ctx->hp.native_handle = (void *)NULL;
   ctx->max_encryption = 0;
   ctx->max_decryption_failure = 0;
   return ctx;
@@ -68,87 +72,17 @@ ngtcp2_crypto_aead *ngtcp2_crypto_aead_init(ngtcp2_crypto_aead *aead,
 }
 
 ngtcp2_crypto_aead *ngtcp2_crypto_aead_retry(ngtcp2_crypto_aead *aead) {
-  return ngtcp2_crypto_aead_init(aead, (void *)EVP_aes_128_gcm());
-}
-
-static const EVP_CIPHER *crypto_ssl_get_aead(SSL *ssl) {
-  switch (SSL_CIPHER_get_id(SSL_get_current_cipher(ssl))) {
-  case TLS1_3_CK_AES_128_GCM_SHA256:
-    return EVP_aes_128_gcm();
-  case TLS1_3_CK_AES_256_GCM_SHA384:
-    return EVP_aes_256_gcm();
-  case TLS1_3_CK_CHACHA20_POLY1305_SHA256:
-    return EVP_chacha20_poly1305();
-  case TLS1_3_CK_AES_128_CCM_SHA256:
-    return EVP_aes_128_ccm();
-  default:
-    return NULL;
-  }
-}
-
-static uint64_t crypto_ssl_get_aead_max_encryption(SSL *ssl) {
-  switch (SSL_CIPHER_get_id(SSL_get_current_cipher(ssl))) {
-  case TLS1_3_CK_AES_128_GCM_SHA256:
-  case TLS1_3_CK_AES_256_GCM_SHA384:
-    return NGTCP2_CRYPTO_MAX_ENCRYPTION_AES_GCM;
-  case TLS1_3_CK_CHACHA20_POLY1305_SHA256:
-    return NGTCP2_CRYPTO_MAX_ENCRYPTION_CHACHA20_POLY1305;
-  case TLS1_3_CK_AES_128_CCM_SHA256:
-    return NGTCP2_CRYPTO_MAX_ENCRYPTION_AES_CCM;
-  default:
-    return 0;
-  }
-}
-
-static uint64_t crypto_ssl_get_aead_max_decryption_failure(SSL *ssl) {
-  switch (SSL_CIPHER_get_id(SSL_get_current_cipher(ssl))) {
-  case TLS1_3_CK_AES_128_GCM_SHA256:
-  case TLS1_3_CK_AES_256_GCM_SHA384:
-    return NGTCP2_CRYPTO_MAX_DECRYPTION_FAILURE_AES_GCM;
-  case TLS1_3_CK_CHACHA20_POLY1305_SHA256:
-    return NGTCP2_CRYPTO_MAX_DECRYPTION_FAILURE_CHACHA20_POLY1305;
-  case TLS1_3_CK_AES_128_CCM_SHA256:
-    return NGTCP2_CRYPTO_MAX_DECRYPTION_FAILURE_AES_CCM;
-  default:
-    return 0;
-  }
-}
-
-static const EVP_CIPHER *crypto_ssl_get_hp(SSL *ssl) {
-  switch (SSL_CIPHER_get_id(SSL_get_current_cipher(ssl))) {
-  case TLS1_3_CK_AES_128_GCM_SHA256:
-  case TLS1_3_CK_AES_128_CCM_SHA256:
-    return EVP_aes_128_ctr();
-  case TLS1_3_CK_AES_256_GCM_SHA384:
-    return EVP_aes_256_ctr();
-  case TLS1_3_CK_CHACHA20_POLY1305_SHA256:
-    return EVP_chacha20();
-  default:
-    return NULL;
-  }
-}
-
-static const EVP_MD *crypto_ssl_get_md(SSL *ssl) {
-  switch (SSL_CIPHER_get_id(SSL_get_current_cipher(ssl))) {
-  case TLS1_3_CK_AES_128_GCM_SHA256:
-  case TLS1_3_CK_CHACHA20_POLY1305_SHA256:
-  case TLS1_3_CK_AES_128_CCM_SHA256:
-    return EVP_sha256();
-  case TLS1_3_CK_AES_256_GCM_SHA384:
-    return EVP_sha384();
-  default:
-    return NULL;
-  }
+  return ngtcp2_crypto_aead_init(aead, NULL);
 }
 
 ngtcp2_crypto_ctx *ngtcp2_crypto_ctx_tls(ngtcp2_crypto_ctx *ctx,
                                          void *tls_native_handle) {
-  SSL *ssl = tls_native_handle;
-  ngtcp2_crypto_aead_init(&ctx->aead, (void *)crypto_ssl_get_aead(ssl));
-  ctx->md.native_handle = (void *)crypto_ssl_get_md(ssl);
-  ctx->hp.native_handle = (void *)crypto_ssl_get_hp(ssl);
-  ctx->max_encryption = crypto_ssl_get_aead_max_encryption(ssl);
-  ctx->max_decryption_failure = crypto_ssl_get_aead_max_decryption_failure(ssl);
+  mbedtls_ssl_context *ssl = tls_native_handle;
+  ngtcp2_crypto_aead_init(&ctx->aead, NULL);
+  ctx->md.native_handle = (void *)NULL;
+  ctx->hp.native_handle = (void *)NULL;
+  ctx->max_encryption = NGTCP2_CRYPTO_MAX_ENCRYPTION_AES_GCM;
+  ctx->max_decryption_failure = NGTCP2_CRYPTO_MAX_DECRYPTION_FAILURE_AES_GCM;
   return ctx;
 }
 
@@ -157,168 +91,137 @@ ngtcp2_crypto_ctx *ngtcp2_crypto_ctx_tls_early(ngtcp2_crypto_ctx *ctx,
   return ngtcp2_crypto_ctx_tls(ctx, tls_native_handle);
 }
 
-static size_t crypto_md_hashlen(const EVP_MD *md) {
-  return (size_t)EVP_MD_size(md);
-}
-
 size_t ngtcp2_crypto_md_hashlen(const ngtcp2_crypto_md *md) {
-  return crypto_md_hashlen(md->native_handle);
-}
-
-static size_t crypto_aead_keylen(const EVP_CIPHER *aead) {
-  return (size_t)EVP_CIPHER_key_length(aead);
+  return mbedtls_md_get_size(md->native_handle);
 }
 
 size_t ngtcp2_crypto_aead_keylen(const ngtcp2_crypto_aead *aead) {
-  return crypto_aead_keylen(aead->native_handle);
-}
-
-static size_t crypto_aead_noncelen(const EVP_CIPHER *aead) {
-  return (size_t)EVP_CIPHER_iv_length(aead);
+  return AES_128_GCM_KEYLEN;
 }
 
 size_t ngtcp2_crypto_aead_noncelen(const ngtcp2_crypto_aead *aead) {
-  return crypto_aead_noncelen(aead->native_handle);
+  return AES_128_GCM_NONCELEN;
+}
+
+size_t ngtcp2_crypto_aead_taglen(const ngtcp2_crypto_aead *aead) {
+  return AES_128_GCM_TAGLEN;
 }
 
 int ngtcp2_crypto_aead_ctx_encrypt_init(ngtcp2_crypto_aead_ctx *aead_ctx,
                                         const ngtcp2_crypto_aead *aead,
                                         const uint8_t *key, size_t noncelen) {
-  const EVP_CIPHER *cipher = aead->native_handle;
-  int cipher_nid = EVP_CIPHER_nid(cipher);
-  EVP_CIPHER_CTX *actx;
+  mbedtls_gcm_context* gcm_ctx = calloc(1, sizeof(mbedtls_gcm_context));
+  mbedtls_gcm_init(gcm_ctx);
 
-  actx = EVP_CIPHER_CTX_new();
-  if (actx == NULL) {
-    return -1;
+  // key length in bits.
+  if (mbedtls_gcm_setkey(
+          gcm_ctx, MBEDTLS_CIPHER_ID_AES, key, AES_128_GCM_KEYLEN_BITS) != 0) {
+    goto cleanup;
   }
-
-  if (!EVP_EncryptInit_ex(actx, cipher, NULL, NULL, NULL) ||
-      !EVP_CIPHER_CTX_ctrl(actx, EVP_CTRL_AEAD_SET_IVLEN, (int)noncelen,
-                           NULL) ||
-      (cipher_nid == NID_aes_128_ccm &&
-       !EVP_CIPHER_CTX_ctrl(actx, EVP_CTRL_AEAD_SET_TAG,
-                            (int)crypto_aead_max_overhead(cipher), NULL)) ||
-      !EVP_EncryptInit_ex(actx, NULL, NULL, key, NULL)) {
-    EVP_CIPHER_CTX_free(actx);
-    return -1;
-  }
-
-  aead_ctx->native_handle = actx;
-
+  aead_ctx->native_handle = gcm_ctx;
   return 0;
+
+cleanup:
+  if (gcm_ctx != NULL) {
+    mbedtls_gcm_free(gcm_ctx);
+    free(gcm_ctx);
+  }
+  return -1;
 }
 
 int ngtcp2_crypto_aead_ctx_decrypt_init(ngtcp2_crypto_aead_ctx *aead_ctx,
                                         const ngtcp2_crypto_aead *aead,
                                         const uint8_t *key, size_t noncelen) {
-  const EVP_CIPHER *cipher = aead->native_handle;
-  int cipher_nid = EVP_CIPHER_nid(cipher);
-  EVP_CIPHER_CTX *actx;
+  mbedtls_gcm_context* gcm_ctx = calloc(1, sizeof(mbedtls_gcm_context));
+  mbedtls_gcm_init(gcm_ctx);
 
-  actx = EVP_CIPHER_CTX_new();
-  if (actx == NULL) {
-    return -1;
+  // key length in bits.
+  if (mbedtls_gcm_setkey(
+          gcm_ctx, MBEDTLS_CIPHER_ID_AES, key, AES_128_GCM_KEYLEN_BITS) != 0) {
+    goto cleanup;
   }
-
-  if (!EVP_DecryptInit_ex(actx, cipher, NULL, NULL, NULL) ||
-      !EVP_CIPHER_CTX_ctrl(actx, EVP_CTRL_AEAD_SET_IVLEN, (int)noncelen,
-                           NULL) ||
-      (cipher_nid == NID_aes_128_ccm &&
-       !EVP_CIPHER_CTX_ctrl(actx, EVP_CTRL_AEAD_SET_TAG,
-                            (int)crypto_aead_max_overhead(cipher), NULL)) ||
-      !EVP_DecryptInit_ex(actx, NULL, NULL, key, NULL)) {
-    EVP_CIPHER_CTX_free(actx);
-    return -1;
-  }
-
-  aead_ctx->native_handle = actx;
-
+  aead_ctx->native_handle = gcm_ctx;
   return 0;
+
+cleanup:
+  if (gcm_ctx != NULL) {
+    mbedtls_gcm_free(gcm_ctx);
+    free(gcm_ctx);
+  }
+  return -1;
 }
 
 void ngtcp2_crypto_aead_ctx_free(ngtcp2_crypto_aead_ctx *aead_ctx) {
-  if (aead_ctx->native_handle) {
-    EVP_CIPHER_CTX_free(aead_ctx->native_handle);
+  mbedtls_gcm_context* gcm_ctx = aead_ctx->native_handle;
+  if (gcm_ctx != NULL) {
+    mbedtls_gcm_free(gcm_ctx);
+    free(gcm_ctx);
   }
 }
 
 int ngtcp2_crypto_cipher_ctx_encrypt_init(ngtcp2_crypto_cipher_ctx *cipher_ctx,
                                           const ngtcp2_crypto_cipher *cipher,
                                           const uint8_t *key) {
-  EVP_CIPHER_CTX *actx;
+  mbedtls_aes_context* aes_ctx = calloc(1, sizeof(mbedtls_aes_context));
+  mbedtls_aes_init(aes_ctx);
 
-  actx = EVP_CIPHER_CTX_new();
-  if (actx == NULL) {
-    return -1;
+  // key length in bits.
+  if (mbedtls_aes_setkey_enc(aes_ctx, key, AES_128_GCM_KEYLEN_BITS) != 0) {
+    goto cleanup;
   }
-
-  if (!EVP_EncryptInit_ex(actx, cipher->native_handle, NULL, key, NULL)) {
-    EVP_CIPHER_CTX_free(actx);
-    return -1;
-  }
-
-  cipher_ctx->native_handle = actx;
-
+  cipher_ctx->native_handle = aes_ctx;
   return 0;
+
+cleanup:
+  if (aes_ctx != NULL) {
+    mbedtls_aes_free(aes_ctx);
+    free(aes_ctx);
+  }
+  return -1;
 }
 
 void ngtcp2_crypto_cipher_ctx_free(ngtcp2_crypto_cipher_ctx *cipher_ctx) {
-  if (cipher_ctx->native_handle) {
-    EVP_CIPHER_CTX_free(cipher_ctx->native_handle);
+  mbedtls_aes_context* aes_ctx = cipher_ctx->native_handle;
+  if (aes_ctx != NULL) {
+    mbedtls_aes_free(aes_ctx);
+    free(aes_ctx);
   }
 }
 
 int ngtcp2_crypto_hkdf_extract(uint8_t *dest, const ngtcp2_crypto_md *md,
                                const uint8_t *secret, size_t secretlen,
                                const uint8_t *salt, size_t saltlen) {
-  const EVP_MD *prf = md->native_handle;
-  int rv = 0;
-  EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
-  size_t destlen = (size_t)EVP_MD_size(prf);
+  const mbedtls_md_info_t* md_info =
+      mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
 
-  if (pctx == NULL) {
-    return -1;
-  }
+  int rv = mbedtls_hkdf_extract(
+      md_info,
+      salt,
+      saltlen,
+      secret,
+      secretlen,
+      dest);
 
-  if (EVP_PKEY_derive_init(pctx) != 1 ||
-      EVP_PKEY_CTX_hkdf_mode(pctx, EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY) != 1 ||
-      EVP_PKEY_CTX_set_hkdf_md(pctx, prf) != 1 ||
-      EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt, (int)saltlen) != 1 ||
-      EVP_PKEY_CTX_set1_hkdf_key(pctx, secret, (int)secretlen) != 1 ||
-      EVP_PKEY_derive(pctx, dest, &destlen) != 1) {
-    rv = -1;
-  }
-
-  EVP_PKEY_CTX_free(pctx);
-
-  return rv;
+  return rv == 0 ? rv : -1;
 }
 
 int ngtcp2_crypto_hkdf_expand(uint8_t *dest, size_t destlen,
                               const ngtcp2_crypto_md *md, const uint8_t *secret,
                               size_t secretlen, const uint8_t *info,
                               size_t infolen) {
-  const EVP_MD *prf = md->native_handle;
-  int rv = 0;
-  EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
-  if (pctx == NULL) {
-    return -1;
-  }
+  const mbedtls_md_info_t* md_info =
+      mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
 
-  if (EVP_PKEY_derive_init(pctx) != 1 ||
-      EVP_PKEY_CTX_hkdf_mode(pctx, EVP_PKEY_HKDEF_MODE_EXPAND_ONLY) != 1 ||
-      EVP_PKEY_CTX_set_hkdf_md(pctx, prf) != 1 ||
-      EVP_PKEY_CTX_set1_hkdf_salt(pctx, (const unsigned char *)"", 0) != 1 ||
-      EVP_PKEY_CTX_set1_hkdf_key(pctx, secret, (int)secretlen) != 1 ||
-      EVP_PKEY_CTX_add1_hkdf_info(pctx, info, (int)infolen) != 1 ||
-      EVP_PKEY_derive(pctx, dest, &destlen) != 1) {
-    rv = -1;
-  }
+  int rv = mbedtls_hkdf_expand(
+      md_info,
+      secret,
+      secretlen,
+      info,
+      infolen,
+      dest,
+      destlen);
 
-  EVP_PKEY_CTX_free(pctx);
-
-  return rv;
+  return rv == 0 ? rv : -1;
 }
 
 int ngtcp2_crypto_encrypt(uint8_t *dest, const ngtcp2_crypto_aead *aead,
@@ -326,22 +229,24 @@ int ngtcp2_crypto_encrypt(uint8_t *dest, const ngtcp2_crypto_aead *aead,
                           const uint8_t *plaintext, size_t plaintextlen,
                           const uint8_t *nonce, size_t noncelen,
                           const uint8_t *ad, size_t adlen) {
-  const EVP_CIPHER *cipher = aead->native_handle;
-  size_t taglen = crypto_aead_max_overhead(cipher);
-  int cipher_nid = EVP_CIPHER_nid(cipher);
-  EVP_CIPHER_CTX *actx = aead_ctx->native_handle;
-  int len;
+  mbedtls_gcm_context* gcm_ctx = aead_ctx->native_handle;
+  assert(gcm_ctx);
 
-  (void)noncelen;
+  // Obtain a pointer to a tag.
+  uint8_t* tag = dest + plaintextlen;
 
-  if (!EVP_EncryptInit_ex(actx, NULL, NULL, NULL, nonce) ||
-      (cipher_nid == NID_aes_128_ccm &&
-       !EVP_EncryptUpdate(actx, NULL, &len, NULL, (int)plaintextlen)) ||
-      !EVP_EncryptUpdate(actx, NULL, &len, ad, (int)adlen) ||
-      !EVP_EncryptUpdate(actx, dest, &len, plaintext, (int)plaintextlen) ||
-      !EVP_EncryptFinal_ex(actx, dest + len, &len) ||
-      !EVP_CIPHER_CTX_ctrl(actx, EVP_CTRL_AEAD_GET_TAG, (int)taglen,
-                           dest + plaintextlen)) {
+  if (mbedtls_gcm_crypt_and_tag(
+          gcm_ctx,
+          MBEDTLS_GCM_ENCRYPT,
+          plaintextlen,
+          nonce,
+          noncelen,
+          ad,
+          adlen,
+          plaintext,
+          dest,
+          AES_128_GCM_TAGLEN,
+          tag) != 0) {
     return -1;
   }
 
@@ -353,31 +258,27 @@ int ngtcp2_crypto_decrypt(uint8_t *dest, const ngtcp2_crypto_aead *aead,
                           const uint8_t *ciphertext, size_t ciphertextlen,
                           const uint8_t *nonce, size_t noncelen,
                           const uint8_t *ad, size_t adlen) {
-  const EVP_CIPHER *cipher = aead->native_handle;
-  size_t taglen = crypto_aead_max_overhead(cipher);
-  int cipher_nid = EVP_CIPHER_nid(cipher);
-  EVP_CIPHER_CTX *actx = aead_ctx->native_handle;
-  int len;
-  const uint8_t *tag;
-
-  (void)noncelen;
-
-  if (taglen > ciphertextlen) {
+  if (ciphertextlen < AES_128_GCM_TAGLEN) {
     return -1;
   }
 
-  ciphertextlen -= taglen;
-  tag = ciphertext + ciphertextlen;
+  ciphertextlen -= AES_128_GCM_TAGLEN;
+  const uint8_t* tag = ciphertext + ciphertextlen;
 
-  if (!EVP_DecryptInit_ex(actx, NULL, NULL, NULL, nonce) ||
-      !EVP_CIPHER_CTX_ctrl(actx, EVP_CTRL_AEAD_SET_TAG, (int)taglen,
-                           (uint8_t *)tag) ||
-      (cipher_nid == NID_aes_128_ccm &&
-       !EVP_DecryptUpdate(actx, NULL, &len, NULL, (int)ciphertextlen)) ||
-      !EVP_DecryptUpdate(actx, NULL, &len, ad, (int)adlen) ||
-      !EVP_DecryptUpdate(actx, dest, &len, ciphertext, (int)ciphertextlen) ||
-      (cipher_nid != NID_aes_128_ccm &&
-       !EVP_DecryptFinal_ex(actx, dest + ciphertextlen, &len))) {
+  mbedtls_gcm_context* gcm_ctx = aead_ctx->native_handle;
+  assert(gcm_ctx);
+
+  if (mbedtls_gcm_auth_decrypt(
+          gcm_ctx,
+          ciphertextlen,
+          nonce,
+          noncelen,
+          ad,
+          adlen,
+          tag,
+          AES_128_GCM_TAGLEN,
+          ciphertext,
+          dest) != 0) {
     return -1;
   }
 
@@ -387,17 +288,17 @@ int ngtcp2_crypto_decrypt(uint8_t *dest, const ngtcp2_crypto_aead *aead,
 int ngtcp2_crypto_hp_mask(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
                           const ngtcp2_crypto_cipher_ctx *hp_ctx,
                           const uint8_t *sample) {
-  static const uint8_t PLAINTEXT[] = "\x00\x00\x00\x00\x00";
-  EVP_CIPHER_CTX *actx = hp_ctx->native_handle;
-  int len;
+  mbedtls_aes_context* aes_ctx = hp_ctx->native_handle;
+  assert(aes_ctx);
+  uint8_t ecb_block[AES_128_ECB_BLKLEN];
 
-  (void)hp;
-
-  if (!EVP_EncryptInit_ex(actx, NULL, NULL, NULL, sample) ||
-      !EVP_EncryptUpdate(actx, dest, &len, PLAINTEXT, sizeof(PLAINTEXT) - 1) ||
-      !EVP_EncryptFinal_ex(actx, dest + sizeof(PLAINTEXT) - 1, &len)) {
+  int rv =
+      mbedtls_aes_crypt_ecb(aes_ctx, MBEDTLS_AES_ENCRYPT, sample, ecb_block);
+  if (rv != 0) {
     return -1;
   }
+
+  memcpy(dest, ecb_block, HP_MASK_LEN);
 
   return 0;
 }
@@ -405,58 +306,41 @@ int ngtcp2_crypto_hp_mask(uint8_t *dest, const ngtcp2_crypto_cipher *hp,
 int ngtcp2_crypto_read_write_crypto_data(ngtcp2_conn *conn,
                                          ngtcp2_crypto_level crypto_level,
                                          const uint8_t *data, size_t datalen) {
-  SSL *ssl = ngtcp2_conn_get_tls_native_handle(conn);
+  mbedtls_ssl_context *ssl = ngtcp2_conn_get_tls_native_handle(conn);
   int rv;
-  int err;
 
-  if (SSL_provide_quic_data(
-          ssl, ngtcp2_crypto_mbedtls_from_ngtcp2_crypto_level(crypto_level),
-          data, datalen) != 1) {
+  if (mbedtls_quic_input_provide_data(ssl, ngtcp2_crypto_mbedtls_from_ngtcp2_crypto_level(crypto_level), data,
+                            datalen) != 0) {
     return -1;
   }
 
   if (!ngtcp2_conn_get_handshake_completed(conn)) {
-    rv = SSL_do_handshake(ssl);
-    if (rv <= 0) {
-      err = SSL_get_error(ssl, rv);
-      switch (err) {
-      case SSL_ERROR_WANT_READ:
-      case SSL_ERROR_WANT_WRITE:
+    while (ssl->state != MBEDTLS_SSL_HANDSHAKE_OVER) {
+      rv = mbedtls_ssl_handshake_step(ssl);
+      if (rv == MBEDTLS_ERR_SSL_WANT_READ) {
         return 0;
-      case SSL_ERROR_WANT_CLIENT_HELLO_CB:
-        return NGTCP2_CRYPTO_OPENSSL_ERR_TLS_WANT_CLIENT_HELLO_CB;
-      case SSL_ERROR_WANT_X509_LOOKUP:
-        return NGTCP2_CRYPTO_OPENSSL_ERR_TLS_WANT_X509_LOOKUP;
-      case SSL_ERROR_SSL:
-        return -1;
-      default:
+      } else if (rv != 0) {
         return -1;
       }
     }
-
     ngtcp2_conn_handshake_completed(conn);
   }
 
-  rv = SSL_process_quic_post_handshake(ssl);
-  if (rv != 1) {
-    err = SSL_get_error(ssl, rv);
-    switch (err) {
-    case SSL_ERROR_WANT_READ:
-    case SSL_ERROR_WANT_WRITE:
+  rv = mbedtls_ssl_quic_post_handshake(ssl);
+
+  switch (rv) {
+    case MBEDTLS_ERR_SSL_WANT_READ:
+    case 0:
       return 0;
-    case SSL_ERROR_SSL:
-    case SSL_ERROR_ZERO_RETURN:
-      return -1;
     default:
       return -1;
-    }
   }
 
   return 0;
 }
 
 int ngtcp2_crypto_set_remote_transport_params(ngtcp2_conn *conn, void *tls) {
-  SSL *ssl = tls;
+  mbedtls_ssl_context *ssl = tls;
   ngtcp2_transport_params_type exttype =
       ngtcp2_conn_is_server(conn)
           ? NGTCP2_TRANSPORT_PARAMS_TYPE_CLIENT_HELLO
@@ -466,7 +350,7 @@ int ngtcp2_crypto_set_remote_transport_params(ngtcp2_conn *conn, void *tls) {
   ngtcp2_transport_params params;
   int rv;
 
-  SSL_get_peer_quic_transport_params(ssl, &tp, &tplen);
+  mbedtls_ssl_get_peer_quic_transport_params(ssl, &tp, &tplen);
 
   rv = ngtcp2_decode_transport_params(&params, exttype, tp, tplen);
   if (rv != 0) {
@@ -485,42 +369,39 @@ int ngtcp2_crypto_set_remote_transport_params(ngtcp2_conn *conn, void *tls) {
 
 int ngtcp2_crypto_set_local_transport_params(void *tls, const uint8_t *buf,
                                              size_t len) {
-  if (SSL_set_quic_transport_params(tls, buf, len) != 1) {
-    return -1;
-  }
-
-  return 0;
+  int rv = mbedtls_ssl_set_quic_transport_params(tls, buf, len);
+  return rv == 0 ? rv : -1;
 }
 
 ngtcp2_crypto_level ngtcp2_crypto_mbedtls_from_ossl_encryption_level(
-    OSSL_ENCRYPTION_LEVEL ossl_level) {
-  switch (ossl_level) {
-  case ssl_encryption_initial:
-    return NGTCP2_CRYPTO_LEVEL_INITIAL;
-  case ssl_encryption_early_data:
-    return NGTCP2_CRYPTO_LEVEL_EARLY;
-  case ssl_encryption_handshake:
-    return NGTCP2_CRYPTO_LEVEL_HANDSHAKE;
-  case ssl_encryption_application:
-    return NGTCP2_CRYPTO_LEVEL_APPLICATION;
-  default:
-    assert(0);
+    mbedtls_ssl_crypto_level mbed_crypto_level) {
+  switch (mbed_crypto_level) {
+    case MBEDTLS_SSL_CRYPTO_LEVEL_INITIAL:
+      return NGTCP2_CRYPTO_LEVEL_INITIAL;
+    case MBEDTLS_SSL_CRYPTO_LEVEL_HANDSHAKE:
+      return NGTCP2_CRYPTO_LEVEL_HANDSHAKE;
+    case MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION:
+      return NGTCP2_CRYPTO_LEVEL_APPLICATION;
+    default:
+      // There is only one valid option left.
+      assert (mbed_crypto_level == MBEDTLS_SSL_CRYPTO_LEVEL_EARLY_DATA);
+      return NGTCP2_CRYPTO_LEVEL_EARLY;
   }
 }
 
-OSSL_ENCRYPTION_LEVEL
+mbedtls_ssl_crypto_level
 ngtcp2_crypto_mbedtls_from_ngtcp2_crypto_level(
     ngtcp2_crypto_level crypto_level) {
-  switch (crypto_level) {
-  case NGTCP2_CRYPTO_LEVEL_INITIAL:
-    return ssl_encryption_initial;
-  case NGTCP2_CRYPTO_LEVEL_HANDSHAKE:
-    return ssl_encryption_handshake;
-  case NGTCP2_CRYPTO_LEVEL_APPLICATION:
-    return ssl_encryption_application;
-  case NGTCP2_CRYPTO_LEVEL_EARLY:
-    return ssl_encryption_early_data;
-  default:
-    assert(0);
+  switch (crypto_level ) {
+    case NGTCP2_CRYPTO_LEVEL_INITIAL:
+      return MBEDTLS_SSL_CRYPTO_LEVEL_INITIAL;
+    case NGTCP2_CRYPTO_LEVEL_HANDSHAKE:
+      return MBEDTLS_SSL_CRYPTO_LEVEL_HANDSHAKE;
+    case NGTCP2_CRYPTO_LEVEL_APPLICATION:
+      return MBEDTLS_SSL_CRYPTO_LEVEL_APPLICATION;
+    default:
+      // There is only one valid option left.
+      assert(crypto_level == NGTCP2_CRYPTO_LEVEL_EARLY);
+      return MBEDTLS_SSL_CRYPTO_LEVEL_EARLY_DATA;
   }
 }

--- a/examples/tls_client_context_mbedtls.h
+++ b/examples/tls_client_context_mbedtls.h
@@ -29,7 +29,6 @@
 #  include <config.h>
 #endif // HAVE_CONFIG_H
 
-#include <openssl/ssl.h>
 #include <mbedtls/ssl.h>
 
 class TLSClientContext {
@@ -39,12 +38,12 @@ public:
 
   int init(const char *private_key_file, const char *cert_file);
 
-  SSL_CTX *get_native_handle() const;
+  mbedtls_ssl_config *get_native_handle() const;
 
   void enable_keylog();
 
 private:
-  SSL_CTX *ssl_ctx_;
+  mbedtls_ssl_config *ssl_ctx_;
 };
 
 #endif // TLS_CLIENT_CONTEXT_MBEDTLS_H

--- a/examples/tls_session_base_mbedtls.cc
+++ b/examples/tls_session_base_mbedtls.cc
@@ -34,21 +34,16 @@ TLSSessionBase::TLSSessionBase() : ssl_{nullptr} {}
 
 TLSSessionBase::~TLSSessionBase() {
   if (ssl_) {
-    SSL_free(ssl_);
+    mbedtls_ssl_free(ssl_);
   }
 }
 
-SSL *TLSSessionBase::get_native_handle() const { return ssl_; }
+mbedtls_ssl_context *TLSSessionBase::get_native_handle() const { return ssl_; }
 
 std::string TLSSessionBase::get_cipher_name() const {
-  return SSL_get_cipher_name(ssl_);
+  return "";
 }
 
 std::string TLSSessionBase::get_selected_alpn() const {
-  const unsigned char *alpn = nullptr;
-  unsigned int alpnlen;
-
-  SSL_get0_alpn_selected(ssl_, &alpn, &alpnlen);
-
-  return std::string{alpn, alpn + alpnlen};
+  return "";
 }

--- a/examples/tls_session_base_mbedtls.h
+++ b/examples/tls_session_base_mbedtls.h
@@ -31,14 +31,14 @@
 
 #include <string>
 
-#include <openssl/ssl.h>
+#include <mbedtls/ssl.h>
 
 class TLSSessionBase {
 public:
   TLSSessionBase();
   ~TLSSessionBase();
 
-  SSL *get_native_handle() const;
+  mbedtls_ssl_context *get_native_handle() const;
 
   std::string get_cipher_name() const;
   std::string get_selected_alpn() const;
@@ -46,7 +46,7 @@ public:
   void enable_keylog() {}
 
 protected:
-  SSL *ssl_;
+  mbedtls_ssl_context *ssl_;
 };
 
 #endif // TLS_SESSION_BASE_MBEDTLS_H


### PR DESCRIPTION
# Additional build instruction

May need turn on additional configure macros in mbedtls
```
#define MBEDTLS_SSL_ALPN
```

```
./configure --with-mbedtls CPPFLAGS="-I/usr/local/include -I$PWD/../mbedtls/include" PKG_CONFIG_PATH=$PWD/../openssl/build/lib/pkgconfig:$PWD/../nghttp3/build/lib/pkgconfig LDFLAGS="-Wl,-rpath,$PWD/../openssl/build/lib,-L/usr/local/lib,-L$PWD/../mbedtls/build/library -lmbedtls -lmbedcrypto -lmbedx509"
make -j
```
# run client against local ngtcp2 server.
```
examples/mbedtlsclient localhost 60036 http://localhost/Makefile
```